### PR TITLE
Prevent dashboard link appearing on introduction page

### DIFF
--- a/resources/views/conferences/introduce.blade.php
+++ b/resources/views/conferences/introduce.blade.php
@@ -17,7 +17,11 @@
             @endif
         </h1>
         @if (auth()->check())
-            <a href="/conferences/{{ $conference->id }}">&lt;- Back to conference dashboard</a>
+            @if(auth()->user()->owns($conference))
+                <a href="/conferences/{{ $conference->id }}">&lt;- Back to conference dashboard</a>
+            @else
+                <a href="/dashboard">&lt;- Back to dashboard</a>
+            @endif
         @endif
 
         <br><br>


### PR DESCRIPTION
If I am logged in and introduce myself on another user's conference
page, I'll have a link to go back to the conference dashboard for that
user's conference.

Whilst the API shouldn't return any content for that conference for my
user, it's best not to link back to it in any case.