### PR TITLE
When making an introduction, update an existing friend record

### DIFF
--- a/app/Conference.php
+++ b/app/Conference.php
@@ -88,18 +88,18 @@ class Conference extends Model
         ]);
 
         return $friend->exists
-            ? $this->existingFriendIntroduction($username, $friend)
-            : $this->newFriendIntroduction($username, $friend);
+            ? $this->markExistingFriendAsIntroduction($username, $friend)
+            : $this->addNewFriendAsIntroduction($username, $friend);
     }
 
-    protected function existingFriendIntroduction($username, $friend)
+    protected function markExistingFriendAsIntroduction($username, $friend)
     {
         $friend->update(['introduction' => true]);
 
         return $friend;
     }
 
-    protected function newFriendIntroduction($username, $friend)
+    protected function addNewFriendAsIntroduction($username, $friend)
     {
         $friend->fill([
             'introduction' => true,

--- a/app/Conference.php
+++ b/app/Conference.php
@@ -94,9 +94,7 @@ class Conference extends Model
 
     protected function existingFriendIntroduction($username, $friend)
     {
-        $friend->introduction = true;
-
-        $friend->save();
+        $friend->update(['introduction' => true]);
 
         return $friend;
     }

--- a/app/Conference.php
+++ b/app/Conference.php
@@ -82,12 +82,18 @@ class Conference extends Model
 
     public function makeIntroduction($username)
     {
-        $friend = new Friend([
-            'username' => $this->normalizeFriendName($username),
-            'type' => $this->isUpcoming() ? 'online' : 'new',
-            'introduction' => true,
-            'met' => ! $this->isUpcoming(),
-        ]);
+        $friend = Friend::firstOrNew(['username' => $this->normalizeFriendName($username)]);
+
+        if ($friend->id) {
+            $friend->introduction = true;
+            $friend->save();
+
+            return $friend;
+        }
+
+        $friend->type = $this->isUpcoming() ? 'online' : 'new';
+        $friend->introduction = true;
+        $friend->met = ! $this->isUpcoming();
 
         $relationship = $this->isUpcoming() ? 'onlineFriends' : 'newFriends';
 

--- a/tests/ConferenceTest.php
+++ b/tests/ConferenceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Conference;
+use App\Friend;
 use App\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
@@ -291,5 +292,17 @@ class ConferenceTest extends TestCase
             'conference_id' => $conference->id,
             'username' => 'michaeldyrynda',
         ]);
+    }
+
+    public function test_it_does_not_duplicate_a_friend_if_they_are_already_on_your_list_and_introducing_themselves()
+    {
+        $user = factory(User::class)->create();
+        $conference = factory(Conference::class)->create(['user_id' => $user->id]);
+
+        $conference->planToMeetOnlineFriend('stauffermatt');
+        $conference->makeIntroduction('stauffermatt');
+
+        $this->assertCount(1, Friend::where('username', 'stauffermatt')->where('conference_id', $conference->id)->get());
+        $this->seeInDatabase('friends', ['username' => 'stauffermatt', 'conference_id' => $conference->id, 'introduction' => true]);
     }
 }


### PR DESCRIPTION
This will prevent cases where a user adds a friend they want to meet, who subsequently introduces themselves, and ends up on the friend list twice.