### PR TITLE
Separate Twitter info into a tweeters table for de-duplication.

### DIFF
--- a/app/Console/Commands/FetchTwitterInfoCommand.php
+++ b/app/Console/Commands/FetchTwitterInfoCommand.php
@@ -2,11 +2,12 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use Abraham\TwitterOAuth\TwitterOAuth;
 use App\Jobs\FetchTwitterInfo;
+use App\Tweeter;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
 use Illuminate\Foundation\Bus\DispatchesJobs;
-use App\Friend;
 
 class FetchTwitterInfoCommand extends Command
 {
@@ -17,7 +18,7 @@ class FetchTwitterInfoCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'twitter:fetch-info {--sync-all : Fetch twitter info for all friends}';
+    protected $signature = 'twitter:fetch-info';
 
     /**
      * The console command description.
@@ -27,45 +28,14 @@ class FetchTwitterInfoCommand extends Command
     protected $description = 'Sync Twitter info for conference friends.';
 
     /**
-     * Twitter OAuth client.
-     *
-     * @var \Abraham\TwitterOAuth\TwitterOAuth
-     */
-    private $twitter;
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct(TwitterOAuth $twitter)
-    {
-        parent::__construct();
-
-        $this->twitter = $twitter;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
-        $friends = Friend::get();
-
-        if (! $this->option('sync-all')) {
-            // @todo: Diff based on something else; this fails now :/
-            // Fetch only the avatars that are missing from disk
-            // $friends = $friends->filter(function ($friend) {
-            //     return ! file_exists(public_path($friend->avatar));
-            // });
-        }
-
-        // @todo: seperate twitter info from twitter pic so we can not re-pull
-        // pic from everyone, and the test above can work again
-        $friends->each(function ($friend) {
-            $this->dispatch(new FetchTwitterInfo($friend));
+        Tweeter::where('updated_at', '<', Carbon::now()->subDay())->get()->each(function ($tweeter) {
+            $this->dispatch(new FetchTwitterInfo($tweeter));
         });
     }
 }

--- a/app/Friend.php
+++ b/app/Friend.php
@@ -6,39 +6,52 @@ use Illuminate\Database\Eloquent\Model;
 
 class Friend extends Model
 {
-    protected $fillable = ['username', 'avatar', 'type', 'met', 'introduction', 'name', 'location', 'description', 'url', 'url_display'];
-    protected $appends = ['avatar_url'];
+    protected $fillable = ['username', 'type', 'met', 'introduction'];
+    protected $appends = ['avatar_url', 'name', 'location', 'description', 'url', 'url_display'];
     protected $casts = ['met' => 'boolean', 'introduction' => 'boolean'];
-
-    protected static function boot()
-    {
-        parent::boot();
-
-        /**
-         * When deleting a friend, if they are the last record in the database
-         * with the given username, delete the cached avatar from storage.
-         */
-        static::deleted(function ($friend) {
-            if (! static::where('username', $friend->username)->exists()) {
-                if (file_exists($avatar_path = public_path($friend->avatar))) {
-                    @unlink($avatar_path);
-                }
-            }
-        });
-    }
 
     public function getAvatarAttribute()
     {
-        return sprintf('assets/img/cache/twitter_profile_pics/%s', sha1($this->username));
+        return $this->tweeter->avatar;
     }
 
     public function getAvatarUrlAttribute()
     {
-        return asset(sprintf('avatar/%s', $this->username));
+        return $this->tweeter->avatar_url;
+    }
+
+    public function getNameAttribute()
+    {
+        return $this->tweeter->name;
+    }
+
+    public function getLocationAttribute()
+    {
+        return $this->tweeter->location;
+    }
+
+    public function getDescriptionAttribute()
+    {
+        return $this->tweeter->description;
+    }
+
+    public function getUrlAttribute()
+    {
+        return $this->tweeter->url;
+    }
+
+    public function getUrlDisplayAttribute()
+    {
+        return $this->tweeter->url_display;
     }
 
     public function markMet()
     {
         return $this->update(['met' => true]);
+    }
+
+    public function tweeter()
+    {
+        return $this->belongsTo(Tweeter::class, 'username', 'username');
     }
 }

--- a/app/Jobs/FetchTwitterInfo.php
+++ b/app/Jobs/FetchTwitterInfo.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use Abraham\TwitterOAuth\TwitterOAuth;
-use App\Friend;
+use App\Tweeter;
 use Exception;
 use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Support\Facades\Log;
@@ -11,19 +11,19 @@ use Illuminate\Support\Facades\Log;
 class FetchTwitterInfo extends Job implements SelfHandling
 {
     /**
-     * @var \App\Friend
+     * @var \App\Tweeter
      */
-    private $friend;
+    private $tweeter;
 
     /**
      * Create a new job instance.
      *
-     * @param  \App\Friend $friend
+     * @param  \App\Tweeter $tweeter
      * @return void
      */
-    public function __construct(Friend $friend)
+    public function __construct(Tweeter $tweeter)
     {
-        $this->friend = $friend;
+        $this->tweeter = $tweeter;
     }
 
     /**
@@ -34,38 +34,38 @@ class FetchTwitterInfo extends Job implements SelfHandling
     public function handle(TwitterOAuth $twitter)
     {
         try {
-            $details = $twitter->get('users/show', ['screen_name' => $this->friend->username]);
+            $details = $twitter->get('users/show', ['screen_name' => $this->tweeter->username]);
 
             if (isset($details->errors)) {
-                // @todo: Handle if it's a non-existent friend?
+                // @todo: Handle if it's a non-existent tweeter?
                 Log::error($details->errors[0]->message);
                 return false;
             }
 
-            $this->friend->name = $details->name;
-            $this->friend->location = $details->location;
-            $this->friend->description = $details->description;
+            $this->tweeter->name = $details->name;
+            $this->tweeter->location = $details->location;
+            $this->tweeter->description = $details->description;
 
             if (array_has($details->entities, 'url')) {
-                $this->friend->url = $details->url;
-                $this->friend->url_display = $details->entities->url->urls[0]->display_url;
+                $this->tweeter->url = $details->url;
+                $this->tweeter->url_display = $details->entities->url->urls[0]->display_url;
             }
 
-            $this->friend->save();
-            Log::info('Synced friend details for ' . $this->friend->username);
+            $this->tweeter->save();
+            Log::info('Synced tweeter details for ' . $this->tweeter->username);
 
             $avatar_url = str_replace('_normal', '', $details->profile_image_url_https);
 
-            if (@file_put_contents(public_path($this->friend->avatar), @file_get_contents($avatar_url))) {
-                Log::info('Synced avatar for ' . $this->friend->username);
+            if (@file_put_contents(public_path($this->tweeter->avatar), @file_get_contents($avatar_url))) {
+                Log::info('Synced avatar for ' . $this->tweeter->username);
                 return true;
             }
         } catch (Exception $e) {
-            Log::error('Failed syncing avatar/details for ' . $this->friend->username . '; exception: ' . $e->getMessage());
+            Log::error('Failed syncing avatar/details for ' . $this->tweeter->username . '; exception: ' . $e->getMessage());
             // No big deal, as we have a default avatar
         }
 
-        Log::error('Failed syncing avatar/details for ' . $this->friend->username);
+        Log::error('Failed syncing avatar for ' . $this->tweeter->username);
         return false;
     }
 }

--- a/app/Listeners/FetchFriendInfo.php
+++ b/app/Listeners/FetchFriendInfo.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\FriendWasAdded;
 use App\Jobs\FetchTwitterInfo;
+use App\Tweeter;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 
 class FetchFriendInfo
@@ -28,8 +29,6 @@ class FetchFriendInfo
      */
     public function handle(FriendWasAdded $event)
     {
-        if (! file_exists(public_path($event->friend->avatar))) {
-            $this->dispatch(new FetchTwitterInfo($event->friend));
-        }
+        Tweeter::ensureExists($event->friend->username);
     }
 }

--- a/app/Tweeter.php
+++ b/app/Tweeter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+use App\Jobs\FetchTwitterInfo;
+use Illuminate\Database\Eloquent\Model;
+
+class Tweeter extends Model
+{
+    protected $guarded = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        /**
+         * When deleting a tweeter, delete the cached avatar from storage.
+         * @todo
+         * Currently not triggered; we need to clean out un-linked tweeters on a cron.
+         */
+        static::deleted(function ($tweeter) {
+            if (file_exists($avatar_path = public_path($tweeter->avatar))) {
+                @unlink($avatar_path);
+            }
+        });
+    }
+
+    public static function ensureExists($username)
+    {
+        \Bus::dispatch(new FetchTwitterInfo(self::firstOrCreate(['username' => $username])));
+    }
+
+    public function getAvatarAttribute()
+    {
+        return sprintf('assets/img/cache/twitter_profile_pics/%s', sha1($this->username));
+    }
+
+    public function getAvatarUrlAttribute()
+    {
+        return asset(sprintf('avatar/%s', $this->username));
+    }
+}

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -34,3 +34,13 @@ $factory->define(App\Friend::class, function (Faker\Generator $faker) {
         'met' => false,
     ];
 });
+
+$factory->define(App\Tweeter::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'location' => $faker->address,
+        'description' => $faker->sentence,
+        'url' => $faker->url,
+        'url_display' => $faker->url,
+    ];
+});

--- a/database/migrations/2017_07_07_141355_create_tweeters_table.php
+++ b/database/migrations/2017_07_07_141355_create_tweeters_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTweetersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tweeters', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('username');
+            $table->string('name')->nullable();
+            $table->string('location')->nullable();
+            $table->string('url')->nullable();
+            $table->string('url_display')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('friends', function (Blueprint $table) {
+            $table->dropColumn(['name', 'location', 'url', 'url_display', 'description']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('tweeters');
+
+        Schema::table('friends', function (Blueprint $table) {
+            $table->string('name')->nullable();
+            $table->string('location')->nullable();
+            $table->string('url')->nullable();
+            $table->string('url_display')->nullable();
+            $table->string('description')->nullable();
+        });
+    }
+}

--- a/nitpick.json
+++ b/nitpick.json
@@ -1,0 +1,7 @@
+{
+    "ignore": [
+        "tests/*",
+        "database/*"
+    ]
+}
+

--- a/tests/FriendTest.php
+++ b/tests/FriendTest.php
@@ -30,30 +30,4 @@ class FriendTest extends TestCase
 
         $this->assertTrue($pulledFriend->met);
     }
-
-    public function test_only_unique_twitter_avatars_are_pulled()
-    {
-        $this->markTestIncomplete('Cannot run until we upgrade Laravel.');
-
-        Bus::fake();
-
-        factory(Friend::class)->create(['conference_id' => 1, 'username' => 'joeschmoe']);
-        factory(Friend::class)->create(['conference_id' => 1, 'username' => 'joeschmoe']);
-        factory(Friend::class)->create(['conference_id' => 1, 'username' => 'jillschmoe']);
-
-        Artisan::call('twitter:fetch-avatars', ['sync-all']);
-
-        $dispatched = [];
-
-        Bus::assertDispatched(FetchTwitterAvatar::class, function ($command) use ($dispatched) {
-            // should not fire twice for the same username
-            if (in_array($command->friend->username, $dispatched)) {
-                return false;
-            }
-
-            $dispatched[] = $command->friend->username;
-
-            return true;
-        });
-    }
 }

--- a/tests/TweeterTest.php
+++ b/tests/TweeterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Abraham\TwitterOAuth\TwitterOAuth;
+use App\Conference;
+use App\Friend;
+use App\Tweeter;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Mockery as m;
+
+class TweeterTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twitter = m::mock(TwitterOAuth::class)->shouldIgnoreMissing();
+
+        app()->instance(TwitterOAuth::class, $this->twitter);
+    }
+
+    /** @test */
+    function friend_passes_tweeter_details()
+    {
+        $user = factory(User::class)->create();
+        $conference = factory(Conference::class)->create(['user_id' => $user->id]);
+        $friend = factory(Friend::class)->create(['conference_id' => $conference]);
+
+        $tweeter = factory(Tweeter::class)->create(['username' => $friend->username]);
+
+        $this->assertEquals($tweeter->name, $friend->name);
+        $this->assertEquals($tweeter->location, $friend->location);
+        $this->assertEquals($tweeter->description, $friend->description);
+        $this->assertEquals($tweeter->url, $friend->url);
+        $this->assertEquals($tweeter->url_display, $friend->url_display);
+    }
+
+    /** @test */
+    function adding_a_friend_adds_new_tweeter_if_doesnt_exist()
+    {
+        $user = factory(User::class)->create();
+        $conference = factory(Conference::class)->create(['user_id' => $user->id]);
+
+        $conference->meetNewFriend('stauffermatt');
+
+        $this->assertEquals(1, Tweeter::count());
+    }
+
+    /** @test */
+    function adding_a_friend_doesnt_create_tweeter_if_one_exists()
+    {
+        $user = factory(User::class)->create();
+        $conference = factory(Conference::class)->create(['user_id' => $user->id]);
+
+        $conference->meetNewFriend('stauffermatt');
+
+        $user2 = factory(User::class)->create();
+        $conference2 = factory(Conference::class)->create(['user_id' => $user2->id]);
+
+        $conference2->meetNewFriend('stauffermatt');
+
+        $this->assertEquals(1, Tweeter::count());
+    }
+
+    /** @test */
+    function fetcher_syncs_friends_data()
+    {
+        $fromTwitter = (object) [
+            'name' => 'Matt Stauffer',
+            'location' => 'Gainesville, FL',
+            'description' => 'A guy',
+            'entities' => [],
+            'profile_image_url_https' => 'abcde',
+        ];
+
+        $this->twitter->shouldReceive('get')->andReturn($fromTwitter);
+
+        $user = factory(User::class)->create();
+        $conference = factory(Conference::class)->create(['user_id' => $user->id]);
+        $conference->meetNewFriend('stauffermatt');
+
+        Tweeter::first()->update(['name' => 'Bob', 'updated_at' => Carbon::now()->subYear()]);
+
+        Artisan::call('twitter:fetch-info');
+
+        $this->assertEquals(Carbon::now()->format('Y-m-d'), Tweeter::first()->updated_at->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
The latest PR introduced syncing name, location, description, url, and url_display from Twitter. De-duplicating this took more work than de-duplicating avatars did prior, so I separated it into a tweeters table.